### PR TITLE
fix: update partner_name clarification and example

### DIFF
--- a/smartnews-ads-conversion-api.md
+++ b/smartnews-ads-conversion-api.md
@@ -29,7 +29,7 @@ https://stg-log.smartnews-ads.com/conversion_api/{api_version}/{partner_name}
 
 | Parameter name | Parameter scope  | Value type | Example    | Description                     |
 |----------------|------------------|------------|------------|---------------------------------|
-| partner_name   | URL parameter    | String     | smartnews  | The name of partner             |
+| partner_name   | URL parameter    | String     | rakuten  | The name of integration side, which should represent business             |
 | api_version    | URL parameter    | String     | v1         | API version                     |
 | Authorization  | Header parameter | String     | v130ad1213 | Token for verifying the request |
 

--- a/smartnews-ads-conversion-api.md
+++ b/smartnews-ads-conversion-api.md
@@ -29,7 +29,7 @@ https://stg-log.smartnews-ads.com/conversion_api/{api_version}/{partner_name}
 
 | Parameter name | Parameter scope  | Value type | Example    | Description                     |
 |----------------|------------------|------------|------------|---------------------------------|
-| partner_name   | URL parameter    | String     | rakuten  | The name of integration side, which should represent business             |
+| partner_name   | URL parameter    | String     | 1aQ234Bc   | The name of integration side, which should represent business. Only digit and alphabet should be used  |
 | api_version    | URL parameter    | String     | v1         | API version                     |
 | Authorization  | Header parameter | String     | v130ad1213 | Token for verifying the request |
 


### PR DESCRIPTION
# Overview 
  
Currently we will let advertiser to perform manual approach in getting approval for partner_name, and obtaining auth token for calling the Conversion API. 

To update the description for `partner_name`, it should be: 1) plain string, 2) string should represent business entity, normally who integrates Conversion API.

Private Repo change: https://github.com/smartnews/smartnews-ads-advertising-api-spec-private/pull/36/files

# Reference
* https://smartnews.slack.com/archives/C03CWLXBEQN/p1736846227443289?thread_ts=1736818808.186149&cid=C03CWLXBEQN
